### PR TITLE
Fix v3.0.2: Hardcoded vault dbengine `mount_point` if vault argument is a `dict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v3.0.2 - 2024-09-10
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/users-package/compare/v3.0.1...v3.0.2 by @obervinov in https://github.com/obervinov/users-package/pull/46
+#### 🐛 Bug Fixes
+* fixed hardcoded vault dbengine `mount_point` if vault argument is a dict
+
+
 ## v3.0.1 - 2024-09-10
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/users-package/compare/v3.0.0...v3.0.1 by @obervinov in https://github.com/obervinov/users-package/pull/45

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "users"
-version = "3.0.1"
+version = "3.0.2"
 description = "This python module is a simple implementation of user management functionality for telegram bots, such as: authentication, authorization and requests limiting."
 authors = ["Bervinov Oleg <obervinov@pm.me>"]
 maintainers = ["Bervinov Oleg <obervinov@pm.me>"]

--- a/users/users.py
+++ b/users/users.py
@@ -47,6 +47,7 @@ class Users:
             :param rate_limits (bool): Enable rate limit functionality. Default is False.
             :param storage (dict): Configuration for initializing the Storage instance.
                 - (str) db_role: The database role for generating credentials from Vault.
+                - (str) db_mount_point: The database mount point for generating credentials from Vault.
 
         Examples:
             >>> users_with_ratelimits = Users(vault=vault_client, rate_limits=True)
@@ -58,9 +59,13 @@ class Users:
                         "type": "approle",
                         "role_id": "role_id",
                         "secret_id": "secret_id"
+                    },
+                    "dbengine": {
+                        "mount_point": "database",
                     }
             }
-            >>> users_with_dict_vault = Users(vault=vault_config)
+            >>> db_config = {"db_role": "my_project_role"}
+            >>> users_with_dict_vault = Users(vault=vault_config, storage=db_config)
         """
         if isinstance(vault, VaultClient):
             self.vault = vault
@@ -68,17 +73,15 @@ class Users:
             self.vault = VaultClient(
                 url=vault.get('url', None),
                 namespace=vault.get('namespace', None),
-                auth=vault.get('auth', None)
+                auth=vault.get('auth', None),
+                dbengine=vault.get('dbengine', None)
             )
         else:
             log.error('[Users]: wrong vault parameters in Users(vault=%s), see doc-string', vault)
             raise VaultInstanceNotSet("Vault instance is not set. Please provide a valid Vault instance as instance or dictionary.")
 
         self.rate_limits = rate_limits
-        self.storage = Storage(
-            vault_client=self.vault,
-            db_role=storage.get('db_role', None)
-        )
+        self.storage = Storage(vault_client=self.vault, db_role=storage.get('db_role', None))
         self._user_status_allow = USER_STATUS_ALLOW
         self._user_status_deny = USER_STATUS_DENY
         self._vault_config_path = USERS_VAULT_CONFIG_PATH

--- a/users/users.py
+++ b/users/users.py
@@ -47,7 +47,6 @@ class Users:
             :param rate_limits (bool): Enable rate limit functionality. Default is False.
             :param storage (dict): Configuration for initializing the Storage instance.
                 - (str) db_role: The database role for generating credentials from Vault.
-                - (str) db_mount_point: The database mount point for generating credentials from Vault.
 
         Examples:
             >>> users_with_ratelimits = Users(vault=vault_client, rate_limits=True)


### PR DESCRIPTION
## v3.0.2 - 2024-09-10
### What's Changed
**Full Changelog**: https://github.com/obervinov/users-package/compare/v3.0.1...v3.0.2 by @obervinov in https://github.com/obervinov/users-package/pull/46
#### 🐛 Bug Fixes
* fixed hardcoded vault dbengine `mount_point` if vault argument is a dict


